### PR TITLE
Fixed the Android crash

### DIFF
--- a/ep-002/tiapp.xml
+++ b/ep-002/tiapp.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ti:app xmlns:ti="http://ti.appcelerator.org">
+    <property name="ti.android.fastdev" type="bool">false</property>
     <deployment-targets>
         <target device="mobileweb">false</target>
         <target device="iphone">true</target>


### PR DESCRIPTION
CommonJS Modules don't work with Fastdev
