### PR TITLE
Fix for SDK 1.8.x / V8 Android

### DIFF
--- a/ep-012/datejs/Resources/app.js
+++ b/ep-012/datejs/Resources/app.js
@@ -2,7 +2,7 @@ var isAndroid = Ti.Platform.osname === 'android';
 Ti.UI.backgroundColor = '#222';
 
 // Include Date.js via CommonJS require()
-require('date');
+var DateJS = require('date').DateJS;
 
 // Suggestions for date values to test
 suggestions = [
@@ -108,7 +108,7 @@ picker.addEventListener('change', function(e) {
 dateText.addEventListener('change', function(e) {
 	var val = dateText.value;
 	if (val.length > 0) {
-		var date = Date.parse(val);
+		var date = DateJS.parse(val);
 		if (date !== null) {
 			label.text = date.toString('dddd, MMMM dd, yyyy h:mm:ss tt');
 		} else {

--- a/ep-012/datejs/Resources/date.js
+++ b/ep-012/datejs/Resources/date.js
@@ -102,3 +102,6 @@ return g._start.call({},s);};}());Date._parse=Date.parse;Date.parse=function(s){
 try{r=Date.Grammar.start.call({},s);}catch(e){return null;}
 return((r[1].length===0)?r[0]:null);};Date.getParseFunction=function(fx){var fn=Date.Grammar.formats(fx);return function(s){var r=null;try{r=fn.call({},s);}catch(e){return null;}
 return((r[1].length===0)?r[0]:null);};};Date.parseExact=function(s,fx){return Date.getParseFunction(fx)(s);};
+
+// save as an export for CommonJS functionality
+exports.DateJS = Date;


### PR DESCRIPTION
This example project no longer works with SDK  1.8.x / V8 on Android, because changes in CommonJS modules aren't exposed beyond the module.  Thus, the changes to Date.prototype aren't visible outside of `date.js`.

To fix this, we simply need to use the `exports` object in `date.js` and refer to this export whenever we need DateJS functionality.
